### PR TITLE
refactor: postgreSQL plugin entity and relation handling

### DIFF
--- a/plugins/catalog-backend-module-postgresql-data/src/PostgreSQLDataProvider.ts
+++ b/plugins/catalog-backend-module-postgresql-data/src/PostgreSQLDataProvider.ts
@@ -6,13 +6,14 @@ import {
   LoggerService,
   SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
-import { extractSchemas } from 'extract-pg-schema';
+import { extractSchemas, ViewColumn } from 'extract-pg-schema';
 import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   Entity,
 } from '@backstage/catalog-model';
 import { convertNameToBackstageCompliant as toBackstageCompliantName } from '@internal/backstage-plugin-entity-name-common';
+import { PostgreSQLTableEntity, PostgreSQLViewEntity } from '@internal/postgresql-data-common';
 
 export class PostgreSQLDataProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
@@ -140,10 +141,12 @@ export class PostgreSQLDataProvider implements EntityProvider {
 
     const extracted = await extractSchemas(this.uri);
 
+    const viewTableMap = new Map<string, string>();
+
     const entities = Object.entries(extracted).flatMap(
       ([schemaName, schema]) => [
         ...schema.tables.map(
-          (table): Entity => ({
+          (table): PostgreSQLTableEntity => ({
             apiVersion: 'geoportia.se/v1alpha1',
             kind: 'Table',
             metadata: {
@@ -157,11 +160,13 @@ export class PostgreSQLDataProvider implements EntityProvider {
                 [ANNOTATION_ORIGIN_LOCATION]: this.uri,
               },
             },
-            spec: table as any,
+            spec: {
+              dependencyOf: [],
+            },
           }),
         ),
         ...schema.views.map(
-          (view): Entity => ({
+          (view): PostgreSQLViewEntity => ({
             apiVersion: 'geoportia.se/v1alpha1',
             kind: 'View',
             metadata: {
@@ -173,7 +178,37 @@ export class PostgreSQLDataProvider implements EntityProvider {
                 [ANNOTATION_ORIGIN_LOCATION]: this.uri,
               },
             },
-            spec: view as any,
+            spec: {
+              dependencyOf: view.columns
+                // @ts-ignore
+                .filter((column: ViewColumn) => {
+                  // Filter out every table dependency that has already been added to the map, to avoid duplicate dependencies. 
+                  // This is needed because some views can have multiple columns depending on the same table, and we only want to add one dependency per table.
+                  if (
+                    column.source &&
+                    column.source.schema &&
+                    column.source.table &&
+                    viewTableMap.get(
+                      toBackstageCompliantName(`${schemaName}.${view.name}`),
+                    ) === undefined
+                  ) {
+                    viewTableMap.set(
+                      toBackstageCompliantName(`${schemaName}.${view.name}`),
+                      toBackstageCompliantName(
+                        `${column.source.schema}.${column.source.table}`,
+                      ),
+                    );
+                    return true;
+                  }
+                  return false;
+                })
+                .map((column: ViewColumn) => ({
+                  kind: 'Table',
+                  namespace: 'default',
+                  // @ts-ignore
+                  name: toBackstageCompliantName(`${column.source.schema}.${column.source.table}`),
+                })),
+            },
           }),
         ),
       ],

--- a/plugins/catalog-backend-module-postgresql-data/src/PostgreSQLEntitiesProcessor.ts
+++ b/plugins/catalog-backend-module-postgresql-data/src/PostgreSQLEntitiesProcessor.ts
@@ -6,20 +6,13 @@ import { LocationSpec } from '@backstage/plugin-catalog-common';
 import {
   Entity,
   getCompoundEntityRef,
+  RELATION_DEPENDENCY_OF,
   RELATION_DEPENDS_ON,
 } from '@backstage/catalog-model';
 import {
   postgresqlTableEntityValidator,
   postgresqlViewEntityValidator,
 } from '@internal/postgresql-data-common';
-
-interface ViewColumn {
-  source: {
-    schema: string;
-    table: string;
-    namespace?: string;
-  };
-}
 
 export class PostgreSQLEntitiesProcessor implements CatalogProcessor {
   getProcessorName() {
@@ -48,44 +41,24 @@ export class PostgreSQLEntitiesProcessor implements CatalogProcessor {
         throw new Error("View entity must have 'spec' defined");
       }
 
-      const seen = new Set<string>();
       // @ts-ignore
-      const dependencies: ViewColumn[] = entity.spec.columns
-        // @ts-ignore
-        .filter(
-          (column: ViewColumn) =>
-            column.source && column.source.schema && column.source.table,
-        )
-        .filter((column: ViewColumn) => {
-          const key = `${column.source.schema}.${column.source.table}`;
-          if (seen.has(key)) return false;
-          seen.add(key);
-          return true;
-        });
+      const dependencies: CompoundEntityRef[] = entity.spec.dependencyOf;
 
       for (const dependency of dependencies) {
         emit({
           type: 'relation',
           relation: {
-            type: RELATION_DEPENDS_ON,
+            type: RELATION_DEPENDENCY_OF,
             source: getCompoundEntityRef(entity),
-            target: {
-              kind: 'Table',
-              namespace: `${dependency.source.namespace || 'default'}`,
-              name: `${dependency.source.schema}.${dependency.source.table}`,
-            },
+            target: dependency,
           },
         });
         emit({
           type: 'relation',
           relation: {
-            type: 'dependencyOf',
+            type: RELATION_DEPENDS_ON,
             target: getCompoundEntityRef(entity),
-            source: {
-              kind: 'Table',
-              namespace: `${dependency.source.namespace || 'default'}`,
-              name: `${dependency.source.schema}.${dependency.source.table}`,
-            },
+            source: dependency,
           },
         });
       }

--- a/plugins/postgresql-data-common/src/index.ts
+++ b/plugins/postgresql-data-common/src/index.ts
@@ -1,16 +1,19 @@
-import { Entity, KindValidator } from '@backstage/catalog-model';
-import { TableDetails, ViewDetails } from 'extract-pg-schema';
+import { CompoundEntityRef, Entity, KindValidator } from '@backstage/catalog-model';
 import { JsonObject } from '@backstage/types';
 
 export interface PostgreSQLTableEntity extends Entity {
   apiVersion: 'geoportia.se/v1alpha1';
   kind: 'Table';
-  spec: TableDetails & JsonObject;
+  spec: {
+    dependencyOf: CompoundEntityRef[];
+  } & JsonObject;
 }
 export interface PostgreSQLViewEntity extends Entity {
   apiVersion: 'geoportia.se/v1alpha1';
   kind: 'View';
-  spec: ViewDetails & JsonObject;
+  spec: {
+    dependencyOf: CompoundEntityRef[];
+  } & JsonObject;
 }
 
 export const postgresqlTableEntityValidator: KindValidator = {


### PR DESCRIPTION
Changed the way the postgreSQL data provider and entity processor works to match the more steamlined way we've set up the Geoserver and ArcGIS SDE plugins. No changes in functionality, but the code should be easier to maintain this way.