### PR TITLE
Fix the show the template bug and add the owner tab

### DIFF
--- a/examples/org.yaml
+++ b/examples/org.yaml
@@ -60,7 +60,7 @@ kind: User
 metadata:
   name: sweco-se1c8x
 spec:
-  memberOf: [users, GG-U-Roll-GeoPortia-Moderator]
+  memberOf: [users]
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-group
 apiVersion: backstage.io/v1alpha1

--- a/plugins/geoportia-metadata-backend/src/permission-policy-module.ts
+++ b/plugins/geoportia-metadata-backend/src/permission-policy-module.ts
@@ -111,6 +111,10 @@ class GeoportiaPermissionPolicy implements PermissionPolicy {
       return { result: AuthorizeResult.ALLOW };
     }
 
+    if (permission.name.startsWith('scaffolder.')) {
+      return { result: AuthorizeResult.ALLOW };
+    }
+
     return { result: AuthorizeResult.DENY };
   }
 }

--- a/plugins/geoportia-metadata/src/scaffolder/templates.tsx
+++ b/plugins/geoportia-metadata/src/scaffolder/templates.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import type { FieldTemplateProps } from '@rjsf/utils';
+import type { FieldTemplateProps, DescriptionFieldProps } from '@rjsf/utils';
 import { Box, Tooltip, Button, Typography } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import AddIcon from '@material-ui/icons/Add';
+
+export const CustomDescriptionFieldTemplate = (_props: DescriptionFieldProps) => {
+  return null;
+};
 
 export const CustomFieldTemplate = (props: FieldTemplateProps) => {
   const { children, schema, rawDescription, classNames, hidden, label, required } = props;
@@ -40,6 +44,7 @@ export const CustomFieldTemplate = (props: FieldTemplateProps) => {
 
 export const createCustomTemplates = (addButtonText: string) => ({
   FieldTemplate: CustomFieldTemplate,
+  DescriptionFieldTemplate: CustomDescriptionFieldTemplate,
   ButtonTemplates: {
     AddButton: (buttonProps: any) => (
       <Button

--- a/plugins/geoportia-metadata/templates/template.yaml
+++ b/plugins/geoportia-metadata/templates/template.yaml
@@ -2,7 +2,7 @@ apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
   name: geoportia-metadata-template
-  title: Ändra databasspecifikation
+  title: Skapa databasspecifikation
   description: En mall för att samla in och hantera metadata för GeoPortia-lager
 spec:
   owner: user:guest
@@ -190,6 +190,58 @@ spec:
                   'ui:widget': 'textarea'
                   'ui:options':
                     rows: 3
+
+    - title: Ägare
+      required:
+        - owner
+      properties:
+        owner:
+          title: Ägare
+          type: object
+          ui:field: GeoPortiaMetadataField
+          ui:options:
+            headerTitle: Ägare
+            showSidebar: true
+            geoportiaMetadataSchema:
+              required:
+                - eskilstunaKommun
+                - organization
+                - databaseUser
+                - allowOneTimeSignature
+              properties:
+                eskilstunaKommun:
+                  type: boolean
+                  title: Eskilstuna kommun
+                  default: false
+                organization:
+                  type: string
+                  title: Organisation
+                  enum:
+                    - 'Välj...'
+                    - 'Databas'
+                    - 'GIS'
+                    - 'Karta'
+                    - 'Plan'
+                    - 'Miljö'
+                  default: 'Välj...'
+                databaseUser: 
+                  type: string
+                  title: Databaseanvändare
+                  enum:
+                    - 'Välj...'
+                    - 'Databas'
+                    - 'GIS'
+                    - 'Karta'
+                    - 'Plan'
+                    - 'Miljö'
+                  default: 'Välj...'
+                allowOneTimeSignature:
+                  type: boolean
+                  title: Tillåt Engångssignatur
+                  default: false
+                  description: Specifikationen kommer exkluderas från den årliga kontroll som sker. Detta innebär att specifikationen endast kommer att behöva signeras en gång. OBS. Vid byte av dataägare återställs detta värde.
+            geoportiaMetadataUiSchema: {}
+
     - title: Metadata
       required:
         - metadata


### PR DESCRIPTION
When we add the permission the create button in the template have been disabled so i fix it in this pr and added the owner tab. 

In the figma it is hard to see all fields because it shows tooltip open so i am not sure if the fields are correct, 

<img width="1070" height="763" alt="image" src="https://github.com/user-attachments/assets/29eeb062-af18-4966-a74a-589c2141ddca" />


Then in another page it shows those fields 

<img width="728" height="797" alt="image" src="https://github.com/user-attachments/assets/a3f4284c-9350-46bb-b1ba-b5dc5bf5fbbc" />


