### PR TITLE
add migration metadata suggestion

### DIFF
--- a/plugins/geoportia-metadata-backend/migrations/20260506100000_metadata_suggestions.js
+++ b/plugins/geoportia-metadata-backend/migrations/20260506100000_metadata_suggestions.js
@@ -1,0 +1,31 @@
+// @ts-check
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('geoportia_metadata_suggestions', table => {
+    table.increments('id');
+
+    table
+      .integer('metadata_id')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('geoportia_metadata')
+      .onDelete('CASCADE');
+
+    table.jsonb('metadata').notNullable();
+
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+
+    table.string('suggested_by').notNullable();
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTable('geoportia_metadata_suggestions');
+};


### PR DESCRIPTION
Migration for database table for suggestions

| Column | Type | Description |
|--------|------|-------------|
| `id` | integer (auto-increment) | Primary key |
| `metadata_id` | integer | Foreign key → `geoportia_metadata.id` (CASCADE on delete) |
| `metadata` | jsonb | Suggested metadata content |
| `created_at` | timestamp | When the suggestion was made (defaults to now) |
| `suggested_by` | string | User who made the suggestion |

Made changes.